### PR TITLE
Add soundtouch alternating speed generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,6 @@
     <audio id="player" controls></audio>
     <audio id="practice-player" controls disabled></audio>
   </main>
-  <script src="script.js"></script>
+  <script type="module" src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable ES module usage and import soundtouch
- create a helper for stretching audio with SoundTouch
- generate practice audio alternating normal and double speed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852f1a1bfe08332b9c1115a1ca67429