### PR TITLE
Add recording option

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
   </header>
   <main>
     <input type="file" accept="audio/*" capture>
+    <button id="record">Record</button>
     <button id="generate" disabled>Generate Practice Audio</button>
     <audio id="player" controls></audio>
     <audio id="practice-player" controls disabled></audio>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,7 @@ const fileInput = document.querySelector('input[type="file"]');
 const player = document.getElementById('player');
 const generateBtn = document.getElementById('generate');
 const practicePlayer = document.getElementById('practice-player');
+const recordBtn = document.getElementById('record');
 let audioBuffer = null;
 let arrayBuffer = null;
 
@@ -27,6 +28,45 @@ if (fileInput && player) {
 
   ['play', 'pause', 'ended'].forEach(evt => {
     player.addEventListener(evt, logBuffer);
+  });
+}
+
+// Record audio using the microphone
+let mediaRecorder = null;
+let recordedChunks = [];
+let recordingStream = null;
+
+if (recordBtn && player) {
+  recordBtn.addEventListener('click', async () => {
+    if (!mediaRecorder || mediaRecorder.state === 'inactive') {
+      try {
+        recordingStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        mediaRecorder = new MediaRecorder(recordingStream);
+        recordedChunks = [];
+
+        mediaRecorder.ondataavailable = (e) => {
+          if (e.data.size > 0) recordedChunks.push(e.data);
+        };
+
+        mediaRecorder.onstop = async () => {
+          const blob = new Blob(recordedChunks, { type: 'audio/webm' });
+          arrayBuffer = await blob.arrayBuffer();
+          player.src = URL.createObjectURL(blob);
+          const ctx = new (window.AudioContext || window.webkitAudioContext)();
+          audioBuffer = await ctx.decodeAudioData(arrayBuffer.slice(0));
+          if (generateBtn) generateBtn.disabled = false;
+        };
+
+        mediaRecorder.start();
+        recordBtn.textContent = 'Stop Recording';
+      } catch (err) {
+        console.error('Microphone error:', err);
+      }
+    } else if (mediaRecorder.state === 'recording') {
+      mediaRecorder.stop();
+      recordingStream.getTracks().forEach(t => t.stop());
+      recordBtn.textContent = 'Record';
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- add a 'Record' button to the page
- use the MediaRecorder API to capture audio from the microphone

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6852f1fbd0108332b20b9da767995025