### PR TITLE
Fix MIME type for recording

### DIFF
--- a/script.js
+++ b/script.js
@@ -77,7 +77,9 @@ if (recordBtn && player) {
         };
 
         mediaRecorder.onstop = async () => {
-          const blob = new Blob(recordedChunks, { type: 'audio/webm' });
+          // Use the actual recording MIME type to maximize browser compatibility
+          const mimeType = recordedChunks[0]?.type || mediaRecorder.mimeType || 'audio/webm';
+          const blob = new Blob(recordedChunks, { type: mimeType });
           arrayBuffer = await blob.arrayBuffer();
           player.src = URL.createObjectURL(blob);
           const ctx = new (window.AudioContext || window.webkitAudioContext)();


### PR DESCRIPTION
## Summary
- use the MIME type of the recorded chunks when creating the blob

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6856f486fc988332aa1f3bfac346f03a